### PR TITLE
perf: 限制图片解码尺寸和并发下载，降低内存占用

### DIFF
--- a/lib/common/widgets/room_card.dart
+++ b/lib/common/widgets/room_card.dart
@@ -167,6 +167,8 @@ class _RoomCardState extends State<RoomCard> {
     try {
       return CachedNetworkImageProvider(
         avatar,
+        maxWidth: 80,
+        maxHeight: 80,
         errorListener: (err) {
           log("CachedNetworkImageProvider: Image failed to load!");
         },
@@ -235,6 +237,8 @@ class _RoomCardState extends State<RoomCard> {
                                 imageUrl: widget.room.cover!,
                                 cacheManager: CustomCacheManager.instance,
                                 fit: BoxFit.fill,
+                                memCacheWidth: 360,
+                                memCacheHeight: 202,
                                 errorWidget: (context, error, stackTrace) => Center(
                                   child: Icon(
                                     color: widget.focusNode.isFoucsed.value ? Colors.black : Colors.white,

--- a/lib/initialized.dart
+++ b/lib/initialized.dart
@@ -28,6 +28,8 @@ class AppInitializer {
   Future<void> initialize() async {
     if (_isInitialized) return;
     WidgetsFlutterBinding.ensureInitialized();
+    // 限制图片缓存为 20MB（适配 1GB 内存设备）
+    PaintingBinding.instance.imageCache.maximumSizeBytes = 20 * 1024 * 1024;
     // 强制横屏
     SystemChrome.setPreferredOrientations([DeviceOrientation.landscapeRight, DeviceOrientation.landscapeLeft]);
     // 全屏

--- a/lib/modules/areas/areas_page.dart
+++ b/lib/modules/areas/areas_page.dart
@@ -243,6 +243,8 @@ class AreasPage extends GetView<AreasListController> {
                     imageUrl: displayImageUrl,
                     cacheManager: CustomCacheManager.instance,
                     fit: BoxFit.fill,
+                    memCacheWidth: 200,
+                    memCacheHeight: 200,
                     errorWidget: (context, error, stackTrace) => Center(
                       child: Icon(
                         Icons.live_tv_rounded,

--- a/lib/modules/areas/favorite_areas_page.dart
+++ b/lib/modules/areas/favorite_areas_page.dart
@@ -104,6 +104,8 @@ class FavoriteAreasPage extends GetView<SettingsService> {
               imageUrl: item.areaPic!,
               cacheManager: CustomCacheManager.instance,
               fit: BoxFit.fill,
+              memCacheWidth: 128,
+              memCacheHeight: 128,
               errorWidget: (context, error, stackTrace) => Center(
                 child: Icon(
                   Icons.live_tv_rounded,

--- a/lib/plugins/cache_manager.dart
+++ b/lib/plugins/cache_manager.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:async';
 import 'package:pure_live/common/utils/app_path_manager.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
@@ -29,22 +30,56 @@ class CustomImageCacheManager {
   }
 }
 
+/// 限制并发下载数的信号量
+class _Semaphore {
+  final int maxCount;
+  int _currentCount = 0;
+  final List<Completer<void>> _waiters = [];
+
+  _Semaphore(this.maxCount);
+
+  Future<void> acquire() async {
+    if (_currentCount < maxCount) {
+      _currentCount++;
+      return;
+    }
+    final completer = Completer<void>();
+    _waiters.add(completer);
+    await completer.future;
+  }
+
+  void release() {
+    if (_waiters.isNotEmpty) {
+      _waiters.removeAt(0).complete();
+    } else {
+      _currentCount--;
+    }
+  }
+}
+
 class HttpFileServiceWithRetry extends HttpFileService {
+  static final _semaphore = _Semaphore(4);
+
   @override
   Future<FileServiceResponse> get(String url, {Map<String, String>? headers}) async {
+    await _semaphore.acquire();
     int retryCount = 0;
     const int maxRetries = 3;
 
-    while (true) {
-      try {
-        return await super.get(url, headers: headers);
-      } catch (e) {
-        retryCount++;
-        if (retryCount >= maxRetries || e.toString().contains('404')) {
-          rethrow;
+    try {
+      while (true) {
+        try {
+          return await super.get(url, headers: headers);
+        } catch (e) {
+          retryCount++;
+          if (retryCount >= maxRetries || e.toString().contains('404')) {
+            rethrow;
+          }
+          await Future.delayed(Duration(milliseconds: 500 * retryCount));
         }
-        await Future.delayed(Duration(milliseconds: 500 * retryCount));
       }
+    } finally {
+      _semaphore.release();
     }
   }
 }

--- a/lib/plugins/cache_network.dart
+++ b/lib/plugins/cache_network.dart
@@ -9,6 +9,8 @@ class CacheNetWorkUtils {
         ? CachedNetworkImage(
             imageUrl: imageUrl,
             cacheManager: CustomCacheManager.instance,
+            memCacheWidth: 200,
+            memCacheHeight: 200,
             placeholder: (context, url) => const CircularProgressIndicator(
                   color: Colors.white,
                 ),


### PR DESCRIPTION
perf: 限制图片解码尺寸和并发下载，降低内存占用

在 1GB 内存的设备上，直播封面图按原始分辨率解码（通常 1080p，~8MB/张），屏幕同时显示 10 张卡片就占用 ~80MB 内存，导致 OOM 闪退。

**改动内容：**
- 房间封面图：解码尺寸限制为 360×202（~0.29MB/张，节省 27 倍）
- 房间头像：限制为 80×80
- 分区图标：限制为 200×200 和 128×128
- 通用缓存图片：限制为 200×200
- 图片下载：添加信号量，并发数限制为 4
- Flutter imageCache：上限设为 20MB（LRU 自动淘汰离屏图片）

**影响范围：** 仅添加 `memCacheWidth`/`memCacheHeight` 参数，不改变任何业务逻辑。