### PR TITLE
perf: 收藏页 MasonryGridView 改为懒加载渲染

### DIFF
--- a/lib/modules/favorite/favorite_page.dart
+++ b/lib/modules/favorite/favorite_page.dart
@@ -93,8 +93,6 @@ class FavoritePage extends GetView<FavoriteController> {
                 crossAxisCount: 5,
                 crossAxisSpacing: 24.w,
                 mainAxisSpacing: 20.w,
-                shrinkWrap: true,
-                physics: const NeverScrollableScrollPhysics(),
                 itemBuilder: (_, i) {
                   var item = controller.tabBottomIndex.value == 0
                       ? controller.onlineRooms[i]


### PR DESCRIPTION
perf: 收藏页 MasonryGridView 改为懒加载渲染

收藏页的 `MasonryGridView` 使用 `shrinkWrap: true` + `NeverScrollableScrollPhysics()`，导致一次性构建所有 RoomCard（含封面图解码），在低内存设备上直接 OOM。

**改动内容：**
- 移除 `shrinkWrap: true` 和 `NeverScrollableScrollPhysics()`
- MasonryGridView 在 `Expanded` 容器内，天然支持按需渲染，只构建屏幕可见的卡片

**影响范围：** 仅删除 2 行代码，不改变任何业务逻辑。MasonryGridView 的懒加载是 Flutter 框架的默认行为。