### PR TITLE
chore: 移除 flutter_inappwebview 依赖

### DIFF
--- a/lib/common/services/bilibili_account_service.dart
+++ b/lib/common/services/bilibili_account_service.dart
@@ -4,7 +4,6 @@ import 'package:pure_live/common/utils/toast_util.dart';
 import 'package:pure_live/core/common/http_client.dart';
 import 'package:pure_live/core/site/bilibili_site.dart';
 import 'package:pure_live/common/utils/hive_pref_util.dart';
-import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:pure_live/common/services/settings_service.dart';
 import 'package:pure_live/common/models/bilibili_user_info_page.dart';
 
@@ -74,7 +73,5 @@ class BiliBiliAccountService extends GetxController {
     setSite();
     HivePrefUtil.setString(kBilibiliCookie, '');
     logined.value = false;
-    CookieManager cookieManager = CookieManager.instance();
-    await cookieManager.deleteAllCookies();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -82,7 +82,6 @@ dependencies:
   dart_tars_protocol:
     git: https://github.com/xiaoyaocz/dart_tars_protocol.git
   html_unescape: ^2.0.0
-  flutter_inappwebview: ^6.2.0-beta.2
   connectivity_plus: ^7.0.0 
   qr_flutter: ^4.1.0 
   flutter_markdown_plus: ^1.0.7


### PR DESCRIPTION
chore: 移除 flutter_inappwebview 依赖

`flutter_inappwebview` 仅用于 Bilibili 登出时清除 WebView cookie。但 Bilibili 登录使用二维码（非 WebView），cookie 存储在 Hive 中，WebView cookie 清除不是功能必需。

**改动内容：**
- 从 `pubspec.yaml` 移除 `flutter_inappwebview` 依赖
- 清理 `bilibili_account_service.dart` 中的空 platform check 代码

**影响：** APK 体积减小约 15MB，消除 WPE WebKit 构建依赖。Bilibili 登出功能不受影响（Hive cookie 已正确清除）。